### PR TITLE
Fix naming string for "sullysmod.jei.grindstone_polishing.info"

### DIFF
--- a/src/generated/resources/assets/sullysmod/lang/en_us.json
+++ b/src/generated/resources/assets/sullysmod/lang/en_us.json
@@ -88,5 +88,5 @@
   "subtitles.entity.tortoise.hurt_baby": "Tortoise baby hurts",
   "subtitles.entity.zombie.destroy_egg": "Egg stomped",
   "sullysmod.jei.grindstone_polishing": "Polishing",
-  "sullysmod.jei.grindstone_polishing.info": "Right-click to polish"
+  "sullysmod.jei.grindstone_polishing.info": "Right click to polish"
 }

--- a/src/main/java/com/uraneptus/sullysmod/core/data/client/SMLangProvider.java
+++ b/src/main/java/com/uraneptus/sullysmod/core/data/client/SMLangProvider.java
@@ -124,7 +124,7 @@ public class SMLangProvider extends LanguageProvider {
 
         //JEI
         add("sullysmod.jei.grindstone_polishing", "Polishing");
-        add("sullysmod.jei.grindstone_polishing.info", "Right-click to polish");
+        add("sullysmod.jei.grindstone_polishing.info", "Right click to polish");
 
         SullysMod.LOGGER.info("LANGUAGE GENERATION COMPLETE");
     }


### PR DESCRIPTION
According to vanilla strings such as "narration.recipe.usage.more", the consistent writing is "Right click", not the hyphenated "Right-click".